### PR TITLE
Added 'G' to REACTION_TIME constant

### DIFF
--- a/lib/constants.js
+++ b/lib/constants.js
@@ -646,6 +646,7 @@ module.exports = {
         OH: 20,
         ZK: 5,
         UL: 5,
+        G: 5,
         UH: 10,
         UH2O: 5,
         XUH2O: 60,


### PR DESCRIPTION
This will be my first pull request ever, so I figured I would try something simple. The 'G' constant is missing from the refactor of REACTION_TIME.

The value can be seen here in the table
https://screeps.com/forum/topic/2123/ptr-changelog-2018-02-28-lab-reaction-time